### PR TITLE
fix bug in the coop mod with downfall, the game crush when player run into the end screen

### DIFF
--- a/src/main/java/chronoMods/coop/CoopCourierRoom.java
+++ b/src/main/java/chronoMods/coop/CoopCourierRoom.java
@@ -1,0 +1,31 @@
+package chronoMods.coop;
+
+import chronoMods.coop.courier.CoopCourier;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.rooms.AbstractRoom;
+
+// for downfall mod
+public class CoopCourierRoom extends AbstractRoom {
+    private chronoMods.coop.courier.CoopCourierRoom realCoopCourierRoom;
+
+    public CoopCourierRoom() {
+        this.realCoopCourierRoom = new chronoMods.coop.courier.CoopCourierRoom();
+    }
+
+    public void onPlayerEntry() {
+        realCoopCourierRoom.onPlayerEntry();
+    }
+
+    public void update() {
+        realCoopCourierRoom.update();
+    }
+
+    public void render(SpriteBatch sb) {
+        realCoopCourierRoom.render(sb);
+    }
+
+    public void dispose() {
+        realCoopCourierRoom.dispose();
+    }
+}


### PR DESCRIPTION
the error messages are
Caused by: java.lang.NoClassDefFoundError: chronoMods/coop/CoopCourierRoom
	at downfall.patches.ui.map.FlipMap$MapFlipper.SWFAct4Override(FlipMap.java:119)
	at downfall.patches.ui.map.FlipMap$MapFlipper.flip(FlipMap.java:237)
	at downfall.patches.ui.map.FlipMap$MapFlipper.flipflipflipflipflip(FlipMap.java:100)